### PR TITLE
高级功能里面header 使用

### DIFF
--- a/modules/agent/utils/utils.go
+++ b/modules/agent/utils/utils.go
@@ -74,7 +74,7 @@ func checkTargetStatus(item *dataobj.DetectedItem) (itemCheckResult *dataobj.Che
 		for _, h := range headers {
 			req.Header(h.Key, h.Value)
 			if h.Key == "Host" {
-                        	req.SetHost(h.Value)
+				req.SetHost(h.Value)
 			}
 		}
 	}

--- a/modules/agent/utils/utils.go
+++ b/modules/agent/utils/utils.go
@@ -60,7 +60,7 @@ func checkTargetStatus(item *dataobj.DetectedItem) (itemCheckResult *dataobj.Che
 	req.SetTLSClientConfig(&tls.Config{InsecureSkipVerify: true})
 	req.SetTimeout(3*time.Second, 10*time.Second)
 	req.Header("Content-Type", "application/json")
-	//req.SetHost(item.Domain)
+	req.SetHost(item.Domain)
 	if item.Data != "" {
 		req.Header("Cookie", item.Data)
 	}

--- a/modules/agent/utils/utils.go
+++ b/modules/agent/utils/utils.go
@@ -60,7 +60,7 @@ func checkTargetStatus(item *dataobj.DetectedItem) (itemCheckResult *dataobj.Che
 	req.SetTLSClientConfig(&tls.Config{InsecureSkipVerify: true})
 	req.SetTimeout(3*time.Second, 10*time.Second)
 	req.Header("Content-Type", "application/json")
-	req.SetHost(item.Domain)
+	//req.SetHost(item.Domain)
 	if item.Data != "" {
 		req.Header("Cookie", item.Data)
 	}
@@ -73,6 +73,9 @@ func checkTargetStatus(item *dataobj.DetectedItem) (itemCheckResult *dataobj.Che
 		headers := parseHeader(item.Header)
 		for _, h := range headers {
 			req.Header(h.Key, h.Value)
+			if h.Key == "Host" {
+                        	req.SetHost(h.Value)
+			}
 		}
 	}
 	resp, err := req.Response()


### PR DESCRIPTION
高级功能里面header 
Host:pay.xxx.com 不生效的问题。

解决问题如下
        api url 形如： （希望访问域名pay.xxx.com 下的特定节点）
               http://172.16.x.x/        
        设置header  Host:pay.xxx.com 
        使请求能够正常请求到指定的  172.16.x.x 节点
验证正常有效，符合预期。
